### PR TITLE
Slides links

### DIFF
--- a/source/palestras2018.rst
+++ b/source/palestras2018.rst
@@ -1,12 +1,12 @@
 Keynotes
-----------------
+--------
 
 
 - `Cássio Botaro - Python Moderno <https://go-talks.appspot.com/github.com/cassiobotaro/talks_and_articles/python_moderno.slide#1>`_
 
 
 Palestras
-----------------
+---------
 
 
 - `Gilson Filho - Automatizando seu fluxo de trabalho com Airflow <https://speakerdeck.com/gilsondev/airflow-automatizando-seu-fluxo-de-trabalho>`_
@@ -26,6 +26,8 @@ Palestras
 - `Vinicius Mesel - Mas cadê as oportunidades Python? <https://speakerdeck.com/vmesel/mas-cade-as-oportunidades-python>`_
 
 - `Regis Santos - Weppy - O framework web para humanos <http://slides.com/regissilva/weppy#/>`_
+
+- `Mariana Bedran - Explorando QuerySets do Django <https://speakerdeck.com/labcodes/explorando-querysets-do-django>`_
 
 
 Tutoriais

--- a/source/pythonsudeste2018.rst
+++ b/source/pythonsudeste2018.rst
@@ -52,6 +52,10 @@ Keynotes
 
 Vídeos
 ------------------------
+
+
+Slides
+------------------------
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
Adicionei o link para meus slides e aproveitei para colocar a listagem dentro do subtítulo certo: estavam em "Vídeos".

Para o evento do ano passado o arquivo de palestras tem os links para os vídeos e o desse ano é para os slides. Seria legal padronizar isso. Só não alterei isso também para não atrapalhar os PRs dos outros palestrantes.